### PR TITLE
fixed get_var bug in baseclass

### DIFF
--- a/Examples/Test.ipynb
+++ b/Examples/Test.ipynb
@@ -9,26 +9,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name '__file__' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-2-e94af395360a>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[1;32mif\u001b[0m \u001b[0m__package__\u001b[0m \u001b[1;32mis\u001b[0m \u001b[0mNone\u001b[0m \u001b[1;32mand\u001b[0m \u001b[0m__file__\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      2\u001b[0m     \u001b[1;32mimport\u001b[0m \u001b[0msys\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m     \u001b[1;32mfrom\u001b[0m \u001b[0mos\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mpath\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m     \u001b[0msys\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpath\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdirname\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdirname\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mabspath\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0m__file__\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mNameError\u001b[0m: name '__file__' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if __package__ is None:\n",
     "    import sys\n",
     "    from os import path\n",
-    "    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))\n",
+    "    sys.path.append(path.dirname(path.dirname(path.abspath(\"Test.ipynb\"))))\n",
     "\n",
     "from FMLC.triggering import triggering\n",
     "from FMLC.baseclasses import eFMU\n",
@@ -69,7 +57,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "if __name__ == '__main__':\n",
@@ -114,7 +104,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "if __name__ == '__main__':\n",
@@ -129,7 +121,8 @@
     "    # Query controller\n",
     "    print ('Log-message', testcontroller.do_step(inputs=inputs))\n",
     "    print ('Input', testcontroller.input)\n",
-    "    print ('Output', testcontroller.output)"
+    "    print ('Output', testcontroller.output)\n",
+    "    print('Output', testcontroller.get_var('output'))"
    ]
   },
   {
@@ -254,7 +247,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": false
+    "scrolled": false,
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -311,9 +305,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3.7.6 64-bit",
    "language": "python",
-   "name": "python2"
+   "name": "python37664bit9a72682f3af34101ab1a1deb1c0d046c"
   },
   "language_info": {
    "codemirror_mode": {
@@ -325,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "version": "3.7.6-final"
   }
  },
  "nbformat": 4,

--- a/FMLC/baseclasses.py
+++ b/FMLC/baseclasses.py
@@ -156,8 +156,9 @@ class eFMU(object):
         ------
         value (float or str): The value of the variable.
         '''
-        exec('x = self.'+name)
-        return x
+        l = locals()
+        exec('x = self.'+name, globals(), l)
+        return l['x']
         
 if __name__ == '__main__':
     print('This is an example controller in form of: c = a * b')

--- a/FMLC/stackedclasses.py
+++ b/FMLC/stackedclasses.py
@@ -7,7 +7,7 @@ from copy import deepcopy as copy_dict
 import logging
 import traceback
 
-from pythonDB.utility import PythonDB_wrapper, write_db, read_db
+from .pythonDB.utility import PythonDB_wrapper, write_db, read_db
 
 import multiprocessing as mp
 #from multiprocessing import Process, Manager


### PR DESCRIPTION
I mainly made these 3 changes:

1. I replaced sys.path.append(path.dirname(path.dirname(path.abspath(__file__)))) with sys.path.append(path.dirname(path.dirname(path.abspath(\"Test.ipynb\")))) because _file_ is sometimes not defined in an interactive shell.

2. fixed the get_var bug in baseclass.py

3. changed from absolute import to relative import when importing pythonDB because the original code somehow didn't work for me. 